### PR TITLE
Add output for eks cluster security group

### DIFF
--- a/odc_eks/modules/eks/outputs.tf
+++ b/odc_eks/modules/eks/outputs.tf
@@ -2,6 +2,10 @@ output "node_instance_profile" {
   value = aws_iam_instance_profile.eks_node.id
 }
 
+output "cluster_security_group" {
+  value = aws_eks_cluster.eks.vpc_config.cluster_security_group_id
+}
+
 output "node_security_group" {
   value = aws_security_group.eks_node.id
 }

--- a/odc_eks/modules/eks/outputs.tf
+++ b/odc_eks/modules/eks/outputs.tf
@@ -3,7 +3,7 @@ output "node_instance_profile" {
 }
 
 output "cluster_security_group" {
-  value = aws_eks_cluster.eks.vpc_config.cluster_security_group_id
+  value = aws_eks_cluster.eks.vpc_config[0].cluster_security_group_id
 }
 
 output "node_security_group" {

--- a/odc_eks/outputs.tf
+++ b/odc_eks/outputs.tf
@@ -35,6 +35,10 @@ output "node_role_arn" {
   value = module.eks.node_role_arn
 }
 
+output "cluster_security_group" {
+  value = module.eks.cluster_security_group
+}
+
 output "node_security_group" {
   value = module.eks.node_security_group
 }


### PR DESCRIPTION
This security group is automatically created alongside the aws_eks_cluster resource - it's used by the control plane and any of it's managed node groups (assuming you don't specify the launch template).