### PR TITLE
Require node group AMI

### DIFF
--- a/odc_eks/modules/eks/variables.tf
+++ b/odc_eks/modules/eks/variables.tf
@@ -41,8 +41,7 @@ variable "user_additional_policy_arn" {
 
 # Worker variables
 variable "ami_image_id" {
-  default     = ""
-  description = "Overwrites the default ami (latest Amazon EKS)"
+  description = "Node group AMI"
 }
 
 variable "node_group_name" {

--- a/odc_eks/modules/eks/worker_image.tf
+++ b/odc_eks/modules/eks/worker_image.tf
@@ -1,22 +1,9 @@
-data "aws_ami" "eks_worker" {
-  filter {
-    name   = "name"
-    values = ["amazon-eks-node-${aws_eks_cluster.eks.version}-v*"]
-  }
-
-  most_recent = true
-  owners      = ["602401143452", "877085696533"] # Amazon EKS AMI Account ID
-}
-
 # EKS currently documents this required userdata for EKS worker nodes to
 # properly configure Kubernetes applications on the EC2 instance.
 # We utilize a Terraform local here to simplify Base64 encoding this
 # information into the AutoScaling Launch Template.
 # More information: https://docs.aws.amazon.com/eks/latest/userguide/launch-workers.html
 locals {
-  # return first non-empty value
-  ami_id = coalesce(var.ami_image_id, data.aws_ami.eks_worker.id)
-
   eks-node-userdata = <<USERDATA
 #!/bin/bash
 set -o xtrace
@@ -47,7 +34,7 @@ USERDATA
 
 resource "aws_launch_template" "node" {
   name_prefix   = aws_eks_cluster.eks.id
-  image_id      = local.ami_id
+  image_id      = var.ami_image_id
   user_data     = base64encode(local.eks-node-userdata)
   instance_type = var.default_worker_instance_type
 
@@ -87,7 +74,7 @@ resource "aws_launch_template" "node" {
 resource "aws_launch_template" "spot" {
   count         = var.spot_nodes_enabled ? 1 : 0
   name_prefix   = aws_eks_cluster.eks.id
-  image_id      = local.ami_id
+  image_id      = var.ami_image_id
   user_data     = base64encode(local.eks-spot-userdata)
   instance_type = var.default_worker_instance_type
 


### PR DESCRIPTION
There are no amazon linux 2 AMIs for EKS 1.33, so the data resource breaks.